### PR TITLE
allow `click.Path` to be CWL `File` instead of `Directory` if `dir_okay=False`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,6 @@ owscontext.xml
 docker-build
 *.ipynb
 .vscode
+.idea
+.run
 catalog.json

--- a/src/click2cwl/cwlparam.py
+++ b/src/click2cwl/cwlparam.py
@@ -138,8 +138,6 @@ class CWLParam(object):
 
     def get_type(self, extended=False):
 
-        cwl_type = None
-
         cwl_types = {}
 
         cwl_types[click.types.Path] = "Directory"
@@ -148,7 +146,12 @@ class CWLParam(object):
         cwl_types[click.types.Choice] = "enum"
         cwl_types[click.types.BoolParamType] = "boolean"
 
-        cwl_type = cwl_types.get(type(self._option.type))
+        option_type = type(self._option.type)
+        cwl_type = cwl_types.get(option_type)
+
+        if option_type is click.types.Path:
+            if not self._option.type.dir_okay:
+                cwl_type = "File"
 
         if self.scatter:
 


### PR DESCRIPTION
Using `@click.option(..., type=click.Path(exists=True, dir_okay=False))` is a common strategy to provide information that a path *will eventually* be created, but is not yet available (an cannot be opened by `click`). Previous behavior was to assume `click.Path` means CWL `Directory` since `click.File` was not used.