### PR TITLE
ensure JSON-serializable CWL enum symbols

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -32,9 +32,10 @@ jobs:
         pip install hatch
     - name: Build and test package
       run: |
-        hatch build         
-        pip install .
+        hatch build
+        pip install '.[test]'
         python tests/test_cwl.py
+        pytest
     - name: Publish package distributions to PyPI (main)
       if: github.ref == 'refs/heads/master'
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,3 +57,14 @@ dependencies = [
 "pyyaml"
 ]
 
+[project.optional-dependencies]
+test = [
+  "pytest",
+]
+
+[tool.pytest.ini_options]
+minversion = "6.0"
+addopts = "-ra"
+testpaths = [
+  "tests"
+]

--- a/src/click2cwl/cwlparam.py
+++ b/src/click2cwl/cwlparam.py
@@ -23,7 +23,7 @@ class CWLParam(object):
                 clt_input = {
                     "type": [{
                         "type": self.input_type,
-                        "symbols": self._option.type.choices,
+                        "symbols": list(self._option.type.choices),
                     }],
                     "inputBinding": {"position": position, "prefix": self.opt},
                 }
@@ -33,7 +33,7 @@ class CWLParam(object):
                 clt_input = {
                     "type": [
                         "null",
-                        {"type": self.input_type, "symbols": self._option.type.choices},
+                        {"type": self.input_type, "symbols": list(self._option.type.choices)},
                     ],
                     "inputBinding": {"position": position, "prefix": self.opt},
                 }
@@ -85,7 +85,7 @@ class CWLParam(object):
                 workflow_param = {
                     "type": [{
                         "type": self.input_type,
-                        "symbols": self._option.type.choices,
+                        "symbols": list(self._option.type.choices),
                     }],
                     "label": self.help,
                     "doc": self.help,
@@ -96,7 +96,7 @@ class CWLParam(object):
                 workflow_param = {
                     "type": [
                         "null",
-                        {"type": self.input_type, "symbols": self._option.type.choices},
+                        {"type": self.input_type, "symbols": list(self._option.type.choices)},
                     ],
                     "label": self.help,
                     "doc": self.help,

--- a/tests/test_cwlparam.py
+++ b/tests/test_cwlparam.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Tests for `click2cwl.cwlparam` module.
+"""
+
+import click
+
+import click2cwl
+
+
+
+@click.command()
+@click.option("--value", type=click.Choice(["A", "B", "C"]), required=True)
+def cli_enum(**kwargs):
+    ...
+
+
+def test_enum_dict():
+    ctx = cli_enum.make_context("cli_enum", ["--value", "A"])
+    c2c = click2cwl.Click2CWL(ctx)
+    exp = click2cwl.CWLExport(c2c)
+    cwl = exp.to_dict()
+    clt = cwl["$graph"][0]
+    wf = cwl["$graph"][1]
+
+    assert list(clt["inputs"]) == ["value"]
+    assert "symbols" in clt["inputs"]["value"]["type"][0]  # list is used to allow optionally having 'null'
+    assert isinstance(clt["inputs"]["value"]["type"][0]["symbols"], list), (
+        "ensure symbols are a Python list, not a tuple to make it JSON serializable as array"
+    )
+    assert clt["inputs"]["value"] == {
+        "inputBinding": {"position": 1, "prefix": "--value"},
+        "type": [
+            {
+                "type": "enum",
+                "symbols": ["A", "B", "C"],
+            }
+        ]
+    }
+
+    assert list(wf["inputs"]) == ["value"]
+    assert "symbols" in wf["inputs"]["value"]["type"][0]
+    assert isinstance(clt["inputs"]["value"]["type"][0]["symbols"], list), (
+        "ensure symbols are a Python list, not a tuple to make it JSON serializable as array"
+    )
+    assert wf["inputs"]["value"] == {  # no binding here since they are in 'steps' between wf/clt
+        "type": [
+            {
+                "type": "enum",
+                "symbols": ["A", "B", "C"],
+            }
+        ]
+    }


### PR DESCRIPTION
Before this change, exporting an `enum` type to YAML would yield the following.

This causes unnecessary "unsafe" types, and fails completely in JSON export unless a converter is provided.

```cwl
inputs:
  value:
    inputBinding:
      position: 1
      prefix: --value
    type:
    - symbols: !!python/tuple  # see here!
      - A
      - B
      - C
      type: enum
```

After this change, the result is the exact same, except that `symbols: [A, B, C]` is returned with pure array natively compatible in JSON and YAML.


PR structure is similar to #9 to allow merge in any order.