### PR TITLE
add missing Click/CWL param type mapping

### DIFF
--- a/src/click2cwl/cwlparam.py
+++ b/src/click2cwl/cwlparam.py
@@ -163,7 +163,10 @@ class CWLParam(object):
         cwl_type = cwl_types.get(option_type)
 
         if cwl_type is None:
-            raise TypeError(f"Unknown CWL type mapping from Click parameter type: {option_type}")
+            raise TypeError(
+                f"Unknown CWL type mapping from Click parameter type: [{option_type}]. "
+                f"Only the following Click parameter types are supported: {list(cwl_types)}"
+            )
 
         if option_type is click.types.Path:
             if not self._option.type.dir_okay:

--- a/src/click2cwl/cwlparam.py
+++ b/src/click2cwl/cwlparam.py
@@ -141,16 +141,29 @@ class CWLParam(object):
 
     def get_type(self, extended=False):
 
-        cwl_types = {}
-
-        cwl_types[click.types.Path] = "Directory"
-        cwl_types[click.types.File] = "File"
-        cwl_types[click.types.StringParamType] = "string"
-        cwl_types[click.types.Choice] = "enum"
-        cwl_types[click.types.BoolParamType] = "boolean"
+        # https://www.commonwl.org/v1.2/CommandLineTool.html#CWLType
+        # https://click.palletsprojects.com/en/stable/parameter-types/
+        # https://click.palletsprojects.com/en/stable/api/#click-api-types
+        cwl_types = {
+            click.types.Path: "Directory",
+            click.types.File: "File",
+            click.types.StringParamType: "string",
+            click.types.DateTime: "string",
+            click.types.UUIDParameterType: "string",
+            click.types.UnprocessedParamType: "string",
+            click.types.Choice: "enum",
+            click.types.BoolParamType: "boolean",
+            click.types.IntParamType: "int",
+            click.types.IntRange: "int",
+            click.types.FloatParamType: "float",
+            click.types.FloatRange: "float",
+        }
 
         option_type = type(self._option.type)
         cwl_type = cwl_types.get(option_type)
+
+        if cwl_type is None:
+            raise TypeError(f"Unknown CWL type mapping from Click parameter type: {option_type}")
 
         if option_type is click.types.Path:
             if not self._option.type.dir_okay:

--- a/tests/test_cwlparam.py
+++ b/tests/test_cwlparam.py
@@ -9,6 +9,7 @@ import click
 import pytest
 
 import click2cwl
+from click2cwl.cwlparam import CWLParam
 
 
 @click.command()
@@ -97,3 +98,24 @@ def test_enum_dict():
             }
         ]
     }
+
+
+@pytest.mark.parametrize(
+    ["click_type", "cwl_type"],
+    [
+        (click.Option(["--test"], type=int), "int"),
+        (click.Option(["--test"], type=float), "float"),
+        (click.Option(["--test"], type=str), "string"),
+        (click.Option(["--test"], type=click.INT), "int"),
+        (click.Option(["--test"], type=click.FLOAT), "float"),
+        (click.Option(["--test"], type=click.STRING), "string"),
+        (click.Option(["--test"], type=click.UUID), "string"),
+        (click.Option(["--test"], type=click.DateTime()), "string"),
+        (click.Option(["--test"], type=click.Choice([1, 2])), "enum"),
+        (click.Option(["--test"], type=click.Path()), "Directory"),
+        (click.Option(["--test"], type=click.File()), "File"),
+    ]
+)
+def test_param_mapping(click_type, cwl_type):
+    param = CWLParam(click_type)
+    assert param.get_type() == cwl_type


### PR DESCRIPTION
Mainly, the `int`, `float` types were missing.

For convenience, other (more specialized) click parameters are added (datetime, uuid, ranges), all mapping to their "basic literal" types without advanced validation due to CWL limitation (https://github.com/common-workflow-language/common-workflow-language/issues/764). 

Add a check in case type could not be resolved to warn the user about it.